### PR TITLE
Correcciones en lógica de primer orden.

### DIFF
--- a/teoria/logica-primer-orden.tex
+++ b/teoria/logica-primer-orden.tex
@@ -1999,7 +1999,7 @@ Luego
     Sea $\mathcal{I}$ interpretación de $\mathcal{L}$ 
     con universo $\mathcal{U}$.
 
-    $F: \mathcal{U} \to \mathcal{U}$ isomorfismo.
+    $F: \mathcal{U} \to \mathcal{U}$ isomorfismo de $\mathcal{I}$ a $\mathcal{I}$.
 
     \medskip
 
@@ -2120,7 +2120,7 @@ mueva dichos elementos.
     Sea $\mathcal{L}$ un lenguaje de primer orden y sea $\mathcal{I}$ una
     interpretación de $\mathcal{L}$ con universo $\mathcal{U}$.
 
-    Sea $F: \mathcal{U} \to \mathcal{U}$ un isomorfismo.
+    Sea $F: \mathcal{U} \to \mathcal{U}$ un isomorfismo de $\mathcal{I}$ a $\mathcal{I}$.
 
     \medskip
 

--- a/teoria/logica-primer-orden.tex
+++ b/teoria/logica-primer-orden.tex
@@ -939,7 +939,7 @@ Los casos en que $\alpha$ es verdadero o falso son los siguientes:
         variables ligadas tal que
         \nota{Decimos que $\alpha(x)$ expresa $A$.}%
         \begin{gather*}
-            V_{\mathcal{I}, v_{x=a}} (\alpha(x)) = 1 \iff x \in A
+            V_{\mathcal{I}, v_{x=a}} (\alpha(x)) = 1 \iff a \in A
         \end{gather*}
 
         \medskip
@@ -951,9 +951,9 @@ Los casos en que $\alpha$ es verdadero o falso son los siguientes:
         \end{gather*}
         Es decir
         \begin{gather*}
-            \text{Si } x \in A
+            \text{Si } a \in A
             \implies V_{\mathcal{I}, v_{x=a}} (\alpha(x)) = 1 \\
-            \text{Si } x \notin A
+            \text{Si } a \notin A
             \implies V_{\mathcal{I}, v_{x=a}} (\alpha(x)) = 0
         \end{gather*}
 


### PR DESCRIPTION
El cambio principal es la corrección del siguiente typo:
(anterior)
![logica comp 1](https://github.com/mzahnd/apuntes-9335-logica-computacional/assets/95503757/b14a9c64-1e7b-459b-9e34-eb6ecb889d1f)

Se cambia x por a
(nuevo)
![logica comp 1 nuevo](https://github.com/mzahnd/apuntes-9335-logica-computacional/assets/95503757/bf461516-5ce2-4f40-be0c-38a066b3a665)

También agregué una aclaración, pero no es esencial
(anterior)
![comp logica 2](https://github.com/mzahnd/apuntes-9335-logica-computacional/assets/95503757/8b87f4a9-2122-4325-9c00-015b490d7c56)

Agrego que el isomorfismo es de I a I
(nuevo)
![comp logica 2 new](https://github.com/mzahnd/apuntes-9335-logica-computacional/assets/95503757/f5bab81c-f509-44cd-9d8e-f78982b818cc)
