### PR TITLE
correcciones de errores menores

### DIFF
--- a/AUTORES.md
+++ b/AUTORES.md
@@ -10,3 +10,4 @@
 - David Wischñevsky
 - Felipe Mindlin
 - Jonathan Liu
+- Tomás Pietravallo

--- a/caratula.tex
+++ b/caratula.tex
@@ -53,6 +53,8 @@
     Tobías Pugliano%
     % \\%
     % Juan Pepe%
+    \\%
+    Tomás Pietravallo%
     
     \vfill
     

--- a/teoria/cardinalidad.tex
+++ b/teoria/cardinalidad.tex
@@ -182,7 +182,7 @@ El conjunto $\mathbb{N}$ es infinito.
         $\implies \exists \; g: \widetilde{A}\to A$ biyectiva y 
         $h:\widetilde{B}\to B$ biyectiva.
 
-        Luego $h^{-1}\circ f \circ g : \widetilde{A} \to B$ es inyectiva por 
+        Luego $h^{-1}\circ f \circ g : \widetilde{A} \to \widetilde{B}$ es inyectiva por 
         composición de funciones inyectivas.
     \item Tarea.
     \item Tarea.

--- a/teoria/logica-proposicional.tex
+++ b/teoria/logica-proposicional.tex
@@ -3208,7 +3208,7 @@ $\exists \; v \text{ valuación}/ v(\Gamma) = 1 \text{ y } v(\alpha) = 0$
                 Luego
                 \begin{align*}
                     \phantom{\implies}& C(\Gamma) = \mathrm{FORM} \\
-                    \implies& C(\Gamma \cup \{ \beta \}) = \mathrm{FORM} 
+                    \implies& C(\Gamma \cup \{ \alpha \}) = \mathrm{FORM} 
                     \notamath{$\forall \beta \in \mathrm{FORM}$} \\
                     \implies& \beta \in C(\Gamma \cup \{ \alpha \})
                 \end{align*}


### PR DESCRIPTION
Hola buenas! 

Me toco cursar lógica 93.35 este cuatri y las sagradas escrituras fueron de mucha ayuda! Mientras estudiaba para el final encontré unos errores chicos que quise corregir para ayudar a mejorar el documento.

Adjunto imágenes con los cambios para que sea mas fácil de revisar

Si tengo tiempo quizás me siente a revisar el documento otra vez a ver si encuentro algún otro error o definición/propiedad que este en mi carpeta pero no en las sagradas

# Cambios:

## [corregir codominio, comparacion de cardinales](https://github.com/mzahnd/apuntes-9335-logica-computacional/commit/05b4dac6793aaee2ad51faa03ba8a001382502c2)

Descripcion: La demostración estaria incompleta si `h^-1 o f o g` fuera de `A_hat` a `B`, en lugar de `A_hat` a `B_hat`. Ademas los dominios/codominios no coinciden en la composición.

> Nota: `f: A -> B`

Antes:
<img width="513" alt="Screenshot 2024-07-12 at 9 01 56 PM" src="https://github.com/user-attachments/assets/bbfd79c9-f7d8-4888-b782-716ed2fd6c97">

Ahora:
<img width="513" alt="Screenshot 2024-07-12 at 8 57 16 PM" src="https://github.com/user-attachments/assets/d85814d0-2110-46e0-847b-c9f932ef14d9">

## [teo. deduccion, corregir implicacion](https://github.com/mzahnd/apuntes-9335-logica-computacional/commit/25067a2285bfc7f1f763d75a324884bd1fd49e99)

Descripción: Caso 2. Gamma insatisfacible: que `beta` pertenezca a las consecuencias de `gamma U beta` no es lo que quiere probarse

Antes:
<img width="513" alt="Screenshot 2024-07-12 at 8 58 39 PM" src="https://github.com/user-attachments/assets/323c70cc-68a8-4693-badf-86757574cee5">

Ahora:
<img width="513" alt="Screenshot 2024-07-12 at 9 05 33 PM" src="https://github.com/user-attachments/assets/149e0d80-e736-4ad4-88f7-33afd5955add">
