### PR TITLE
Typo: Replace A with A* in definition 26

### DIFF
--- a/teoria/logica-proposicional.tex
+++ b/teoria/logica-proposicional.tex
@@ -124,7 +124,7 @@ $A^{*}$ es infinito.
 
 
 \begin{definicion}{Igualdad de expresiones}{}
-    Sean las expresiones $E$ y $F$ sobre $A$.
+    Sean las expresiones $E$ y $F$ sobre $A^*$.
 
     \medskip
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/c0aaf8d5-28da-4b18-9cdb-045e2c38ce97)
