### PR TITLE
Add observation after the definition of consequences

### DIFF
--- a/teoria/logica-proposicional.tex
+++ b/teoria/logica-proposicional.tex
@@ -2837,6 +2837,15 @@ Decidir si $\Gamma$ es satisfacible.
 Decimos que $\alpha \notin C(\Gamma)$ si
 $\exists \; v \text{ valuación}/ v(\Gamma) = 1 \text{ y } v(\alpha) = 0$
 
+\bigskip
+\textit{Observación:}
+\begin{enumerate}
+    \item $\Gamma \subseteq C(\Gamma)$
+    \item $\text{TAUTOLOGÍAS} \subseteq C(\Gamma)$
+\end{enumerate}
+Observar también que el conjunto de las consecuencias es siempre infinito.
+
+
 \subsubsection{Ejemplos}
 
 \begin{enumerate}


### PR DESCRIPTION
Agrego la siguiente observacion luego de la definicion de consecuencias:

> Observación:
> 1. Γ⊆C(Γ)
> 2. TAUTOLOGÍAS ⊆C(Γ)
> Observar también que el conjunto de las consecuencias es siempre infinito.